### PR TITLE
Fix single GPU training and model output

### DIFF
--- a/model.py
+++ b/model.py
@@ -40,7 +40,7 @@ class MusicTransformer(torch.nn.Module):
             _, _, look_ahead_mask = utils.get_masked_with_pad_tensor(self.max_seq, x, x, config.pad_token)
             decoder, w = self.Decoder(x, mask=look_ahead_mask)
             fc = self.fc(decoder)
-            return fc.contiguous() if self.training else fc.contiguous(), [weight.contiguous() for weight in w]
+            return fc.contiguous() if self.training else (fc.contiguous(), [weight.contiguous() for weight in w])
         else:
             return self.generate(x, length, None).contiguous().tolist()
 

--- a/train.py
+++ b/train.py
@@ -135,7 +135,8 @@ for e in range(config.epochs):
 
         # switch output device to: gpu-1 ~ gpu-n
         sw_start = time.time()
-        mt.output_device = idx % (torch.cuda.device_count() -1) + 1
+        if torch.cuda.device_count() > 1:
+            mt.output_device = idx % (torch.cuda.device_count() -1) + 1
         sw_end = time.time()
         if config.debug:
             print('output switch time: {}'.format(sw_end - sw_start) )


### PR DESCRIPTION
When running on a single GPU machine, the code which updates the device to use raises ZeroDivisionError so I fixed this in `train.py`.
I also fixed model output (probably due to typo?) which raises an error when training.

Any feedback welcome.
Thanks @jason9693  for your work on this.